### PR TITLE
Add file loader abstraction and tests

### DIFF
--- a/Assets/Scripts/Managers/IFileLoader.cs
+++ b/Assets/Scripts/Managers/IFileLoader.cs
@@ -1,0 +1,5 @@
+public interface IFileLoader
+{
+    string ReadAllText(string path);
+    void WriteAllText(string path, string content);
+}

--- a/Assets/Scripts/Managers/IFileLoader.cs.meta
+++ b/Assets/Scripts/Managers/IFileLoader.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a1946395560c4a85a71c1a69b1e1dc14
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Managers/SaveLoadManager.cs
+++ b/Assets/Scripts/Managers/SaveLoadManager.cs
@@ -32,6 +32,7 @@ public class SaveLoadManager : MonoBehaviour
     public static SaveLoadManager SaveLoadInstance { get; private set; }
     private DirectoryInfo dir;
     public FileInfo[] info;
+    public IFileLoader FileLoader { get; set; } = new SystemFileLoader();
 
 
     public void refreshDirectory()
@@ -73,20 +74,25 @@ public class SaveLoadManager : MonoBehaviour
         }
 
         string json = JsonConvert.SerializeObject(export, Formatting.Indented);
-        File.WriteAllText(filePath, json);
+        FileLoader.WriteAllText(filePath, json);
         Debug.Log($"Map saved to: {filePath}");
         refreshDirectory();
     }
 
     public static Board LoadBoardFromJson(string filePath, Map mapContext, Transform parent)
     {
-        if (!File.Exists(filePath))
+        IFileLoader loader = SaveLoadInstance != null ? SaveLoadInstance.FileLoader : new SystemFileLoader();
+        string json;
+        try
+        {
+            json = loader.ReadAllText(filePath);
+        }
+        catch (IOException)
         {
             Debug.LogError("File not found: " + filePath);
             return null;
         }
 
-        string json = File.ReadAllText(filePath);
         ExportData data = JsonConvert.DeserializeObject<ExportData>(json);
 
         Dictionary<string, TileDataSO> idLookup = new Dictionary<string, TileDataSO>();

--- a/Assets/Scripts/Managers/SystemFileLoader.cs
+++ b/Assets/Scripts/Managers/SystemFileLoader.cs
@@ -1,0 +1,14 @@
+using System.IO;
+
+public class SystemFileLoader : IFileLoader
+{
+    public string ReadAllText(string path)
+    {
+        return File.ReadAllText(path);
+    }
+
+    public void WriteAllText(string path, string content)
+    {
+        File.WriteAllText(path, content);
+    }
+}

--- a/Assets/Scripts/Managers/SystemFileLoader.cs.meta
+++ b/Assets/Scripts/Managers/SystemFileLoader.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6365a40370284b019da02e6298ff0f19
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Tests/EditMode/LoadBoardFromJsonTests.cs
+++ b/Assets/Tests/EditMode/LoadBoardFromJsonTests.cs
@@ -1,0 +1,64 @@
+using NUnit.Framework;
+using UnityEngine;
+using System.Collections.Generic;
+
+public class LoadBoardFromJsonTests
+{
+    private class FakeFileLoader : IFileLoader
+    {
+        private readonly string _content;
+        public FakeFileLoader(string content) { _content = content; }
+        public string ReadAllText(string path) => _content;
+        public void WriteAllText(string path, string content) { }
+    }
+
+    [Test]
+    public void LoadBoardFromJson_DeserializesWithoutFileSystem()
+    {
+        // Arrange sample JSON with two tiles
+        string json = "{\n" +
+            "  \"TileTypeIDs\": [\"A\", \"B\"],\n" +
+            "  \"Board\": {\n" +
+            "    \"x_Height\": 2,\n" +
+            "    \"y_Width\": 1,\n" +
+            "    \"Tiles\": [[{ \"TileTypeID\": \"A\", \"Height\": 0 }, { \"TileTypeID\": \"B\", \"Height\": 1 }]]\n" +
+            "  }\n" +
+            "}";
+
+        var mapGO = new GameObject("Map");
+        var map = mapGO.AddComponent<Map>();
+        map.MapSize = new Vector2Int(2, 1);
+        map.innerSize = 0.5f;
+        map.outerSize = 1f;
+        map.isFlatTopped = true;
+        map.TileTypes = new List<TileDataSO>();
+
+        var typeA = ScriptableObject.CreateInstance<TileDataSO>();
+        typeA.UniqueID = "A";
+        typeA.TilePrefab = new GameObject("A_prefab");
+        typeA.BaseMat = new Material(Shader.Find("Standard"));
+        map.TileTypes.Add(typeA);
+
+        var typeB = ScriptableObject.CreateInstance<TileDataSO>();
+        typeB.UniqueID = "B";
+        typeB.TilePrefab = new GameObject("B_prefab");
+        typeB.BaseMat = typeA.BaseMat;
+        map.TileTypes.Add(typeB);
+
+        var slmGO = new GameObject("SaveLoad");
+        var slm = slmGO.AddComponent<SaveLoadManager>();
+        slm.FileLoader = new FakeFileLoader(json);
+
+        // Act
+        Board board = SaveLoadManager.LoadBoardFromJson("dummy", map, map.transform);
+
+        // Assert
+        Assert.IsNotNull(board);
+        Assert.AreEqual(2, board._size_X);
+        Assert.AreEqual(1, board._size_Y);
+        Assert.AreEqual(typeA, board.get_Tile(0,0).Data);
+        Assert.AreEqual(0f, board.get_Tile(0,0).Height);
+        Assert.AreEqual(typeB, board.get_Tile(1,0).Data);
+        Assert.AreEqual(1f, board.get_Tile(1,0).Height);
+    }
+}

--- a/Assets/Tests/EditMode/LoadBoardFromJsonTests.cs.meta
+++ b/Assets/Tests/EditMode/LoadBoardFromJsonTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9dd23f75e1e84abdb4d7f645dbe45c27
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add `IFileLoader` abstraction and a `SystemFileLoader` implementation
- refactor `SaveLoadManager` to use the new file loader
- add an edit mode test to deserialize JSON without disk access

## Testing
- `nunit3-console Assets/Tests/EditMode/EditModeTests.dll` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fb2dca28c832fbc30d22a5641ce08