### PR TITLE
Add offset and lookup unit tests

### DIFF
--- a/Assets/Scripts/Managers/SaveLoadManager.cs
+++ b/Assets/Scripts/Managers/SaveLoadManager.cs
@@ -115,7 +115,9 @@ public class SaveLoadManager : MonoBehaviour
                 GameObject holder = new GameObject($"Hex {x},{y}", typeof(Tile));
                 Tile tile = holder.GetComponent<Tile>();
                 tile.Data = tileType;
-                tile.SetPositionAndHeight(new Vector2Int(x, y), x, y, sTile.Height);
+                int q = x - board.qOffset;
+                int r = y - board.rOffset;
+                tile.SetPositionAndHeight(new Vector2Int(x, y), q, r, sTile.Height);
                 Vector3 tilePosition = mapContext.GetHexPositionFromCoordinate(new Vector2Int(x, y));
                 tilePosition.y += tile.Height / 2;
                 holder.transform.position = tilePosition;

--- a/Assets/Scripts/Map/Board.cs
+++ b/Assets/Scripts/Map/Board.cs
@@ -7,16 +7,23 @@ public class Board
     public int _size_X { get; private set; }
     public int _size_Y { get; private set; }
 
+    public int qOffset { get; private set; }
+    public int rOffset { get; private set; }
+
     private Tile[,] _board_Contents;
+    private Dictionary<Vector3Int, Tile> cubeLookup;
 
     //Additive vectors for assigning neighbours 
     private Vector3Int[] directions = new Vector3Int[6] { new Vector3Int(1, -1, 0), new Vector3Int(1, 0, -1), new Vector3Int(0, 1, -1),new Vector3Int(-1, 1, 0), new Vector3Int(-1, 0, 1), new Vector3Int(0, -1, 1) };
    
-    public Board(Vector2Int coordinates)
+    public Board(Vector2Int coordinates, int qOffset = int.MinValue, int rOffset = int.MinValue)
     {
         _size_Y = coordinates.y;
         _size_X = coordinates.x;
+        this.qOffset = qOffset == int.MinValue ? _size_X / 2 : qOffset;
+        this.rOffset = rOffset == int.MinValue ? _size_Y / 2 : rOffset;
         _board_Contents = new Tile[_size_X, _size_Y];
+        cubeLookup = new Dictionary<Vector3Int, Tile>();
     }
 
     public Tile get_Tile(int x, int y)
@@ -33,8 +40,17 @@ public class Board
 
     public void set_Tile(int x, int y, Tile toset)
     {
+        Tile existing = _board_Contents[x, y];
+        if (existing != null)
+        {
+            Vector3Int oldKey = new Vector3Int(existing.QAxis, existing.RAxis, existing.SAxis);
+            cubeLookup.Remove(oldKey);
+        }
+
         toset.SetPosition(new Vector2Int(x, y));
         _board_Contents[x, y] = toset;
+        Vector3Int cube = new Vector3Int(toset.QAxis, toset.RAxis, toset.SAxis);
+        cubeLookup[cube] = toset;
     }
 
     public void swap_Tiles(Vector2Int Tile1, Vector2Int Tile2)
@@ -67,13 +83,8 @@ public class Board
     }
     public Tile SearchTileByCubeCoordinates(int q, int r, int s)
     {
-        int centerX = _size_X / 2;
-        int centerY = _size_Y / 2;
-
-        // Convert cube coordinates (q, r, s) to array indices (x, y)
-        // This conversion depends on how your array and cube coordinates are related
-        int x = q + centerX;
-        int y = r + centerY;
+        int x = q + qOffset;
+        int y = r + rOffset;
 
         // Check if the calculated indices are within bounds
         if (x >= 0 && x < _board_Contents.GetLength(0) && y >= 0 && y < _board_Contents.GetLength(1))
@@ -89,15 +100,8 @@ public class Board
 
     public Tile GetTileByCube(Vector3Int cubeCoords)
     {
-        // Iterate all tiles or have a dictionary for faster lookup (preferred)
-        foreach (var tile in GetAllTiles())
-        {
-            if (tile.QAxis == cubeCoords.x && tile.RAxis == cubeCoords.y && tile.SAxis == cubeCoords.z)
-            {
-                return tile;
-            }
-        }
-        return null;
+        cubeLookup.TryGetValue(cubeCoords, out Tile tile);
+        return tile;
     }
 
     // Return all tiles in the board (implement if you don't have it)

--- a/Assets/Scripts/Map/BoardRotator.cs
+++ b/Assets/Scripts/Map/BoardRotator.cs
@@ -42,7 +42,9 @@ public static class BoardRotator
         int width = maxQ - minQ + 1;
         int height = maxR - minR + 1;
 
-        Board rotatedBoard = new Board(new Vector2Int(width, height));
+        int qOffset = -minQ;
+        int rOffset = -minR;
+        Board rotatedBoard = new Board(new Vector2Int(width, height), qOffset, rOffset);
 
         // Step 3: Instantiate rotated tiles and set them into new board
         for (int i = 0; i < originalTiles.Count; i++)
@@ -52,10 +54,12 @@ public static class BoardRotator
 
             int offsetX = rotated.x - minQ;
             int offsetY = rotated.y - minR;
+            int q = offsetX - rotatedBoard.qOffset;
+            int r = offsetY - rotatedBoard.rOffset;
 
             Tile newTile = Object.Instantiate(oldTile);
             newTile.name = oldTile.name + $"_rotated_{rotation}";
-            newTile.SetQUSPosition(rotated.x, rotated.y);
+            newTile.SetQUSPosition(q, r);
             newTile.SetHeight(oldTile.Height);
             newTile.SetPosition(new Vector2Int(offsetX, offsetY));
 

--- a/Assets/Scripts/Map/GenerateEmptyAir.cs
+++ b/Assets/Scripts/Map/GenerateEmptyAir.cs
@@ -7,14 +7,12 @@ public class GenerateEmptyAir : MonoBehaviour, IGenerate
     public Board Generate(Map Data)
     {
         Board PlayArea = new Board(Data.MapSize);
-        int qStart = -Data.MapSize.x / 2;
-        int rStart = -Data.MapSize.y / 2;
         for (int x = 0; x < Data.MapSize.x; x++)
         {
             for (int y = 0; y < Data.MapSize.y; y++)
             {
-                int q = qStart + x;
-                int r = rStart + y;
+                int q = x - PlayArea.qOffset;
+                int r = y - PlayArea.rOffset;
                 GameObject holder = new GameObject($"Hex {x},{y}", typeof(Tile));
                 Tile tile = holder.GetComponent<Tile>();
                 tile.Data = Data.TileTypes[0];

--- a/Assets/Scripts/Map/GenerateFromBoard.cs
+++ b/Assets/Scripts/Map/GenerateFromBoard.cs
@@ -18,8 +18,8 @@ public class GenerateFromBoard : MonoBehaviour, IGenerate
                 if (tile == null)
                     continue;
 
-                int q = -width / 2 + x;
-                int r = -height / 2 + y;
+                int q = x - playArea.qOffset;
+                int r = y - playArea.rOffset;
 
                 tile.SetPositionAndHeight(new Vector2Int(x, y), q, r, tile.Data == Data.TileTypes[0] ? 5 : 20);
                 Vector3 tilePosition = Data.GetHexPositionFromCoordinate(new Vector2Int(x, y));

--- a/Assets/Scripts/Map/RandomGeneration.cs
+++ b/Assets/Scripts/Map/RandomGeneration.cs
@@ -7,14 +7,12 @@ public class RandomGeneration : MonoBehaviour, IGenerate
     public Board Generate(Map Data)
     {
         Board PlayArea = new Board(Data.MapSize);
-        int qStart = -Data.MapSize.x / 2;
-        int rStart = -Data.MapSize.y / 2;
         for (int x = 0; x < Data.MapSize.x; x++)
         {
             for (int y = 0; y < Data.MapSize.y; y++)
             {
-                int q = qStart + x;
-                int r = rStart + y;
+                int q = x - PlayArea.qOffset;
+                int r = y - PlayArea.rOffset;
                 GameObject holder = new GameObject($"Hex {x},{y}", typeof(Tile));
                 Tile tile = holder.GetComponent<Tile>();
                 tile.Data = Data.TileTypes[Random.Range(0, 2)];

--- a/Assets/Tests/EditMode/BoardOffsetTests.cs
+++ b/Assets/Tests/EditMode/BoardOffsetTests.cs
@@ -1,0 +1,46 @@
+using NUnit.Framework;
+using UnityEngine;
+
+/*
+ * These tests validate the new qOffset/rOffset logic and dictionary based cube lookup.
+ *
+ * Offsets shift the cube origin to the center of the board. For a 3x3 board the
+ * layout looks like:
+ *
+ *   (-1,1)  (0,1)  (1,1)
+ *   (-1,0)  (0,0)  (1,0)
+ *   (-1,-1) (0,-1) (1,-1)
+ *
+ * Cube (0,0,0) corresponds to board index (1,1) when offsets are (1,1).
+ */
+public class BoardOffsetTests
+{
+    private Tile CreateTile(Vector2Int pos, int q, int r)
+    {
+        GameObject go = new GameObject();
+        Tile tile = go.AddComponent<Tile>();
+        tile.Data = ScriptableObject.CreateInstance<TileDataSO>();
+        tile.SetPositionAndHeight(pos, q, r, 0);
+        return tile;
+    }
+
+    [Test]
+    public void SearchTileByCube_UsesOffsets()
+    {
+        Board board = new Board(new Vector2Int(3,3)); // qOffset/rOffset default to 1
+        Tile center = CreateTile(new Vector2Int(1,1), 0,0);
+        board.set_Tile(1,1,center);
+        Tile looked = board.SearchTileByCubeCoordinates(0,0,0);
+        Assert.AreEqual(center, looked);
+    }
+
+    [Test]
+    public void GetTileByCube_ReturnsFromDictionary()
+    {
+        Board board = new Board(new Vector2Int(3,3));
+        Tile tile = CreateTile(new Vector2Int(2,0), 1,-1);
+        board.set_Tile(2,0,tile);
+        Vector3Int cube = new Vector3Int(1,-1,0);
+        Assert.AreEqual(tile, board.GetTileByCube(cube));
+    }
+}


### PR DESCRIPTION
## Summary
- store qOffset/rOffset on `Board` and use them when searching by cube coords
- maintain a cube coordinate lookup dictionary for constant time access
- generate tiles using the offsets in all generators and merge helpers
- rotate boards with the new offset logic
- adjust JSON loading to compute cube coordinates correctly
- add unit tests covering the offset behaviour and dictionary lookup

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fb27af078832f9c5a2e36a5cadfa0