### PR TITLE
Guard debug logs

### DIFF
--- a/Assets/Scripts/Map/Board.cs
+++ b/Assets/Scripts/Map/Board.cs
@@ -63,7 +63,9 @@ public class Board
         toset.Column = x;
         toset.Row = y;
 
+#if UNITY_EDITOR
         Debug.Log($"set_Tile: offset=({x},{y}) → cube={newCube}");
+#endif
     }
 
 

--- a/Assets/Scripts/Map/MapMerge.cs
+++ b/Assets/Scripts/Map/MapMerge.cs
@@ -138,7 +138,9 @@ public class MapMerge : MonoBehaviour
         map.MapSize = new Vector2Int(mergedWidth, mergedHeight);
         map.SetNeighbours(map.PlayArea, map.isFlatTopped);
         map.setFirstHex();
+#if UNITY_EDITOR
         Debug.Log("Merged boards into map.");
+#endif
     }
 
 
@@ -157,7 +159,9 @@ public class MapMerge : MonoBehaviour
                     // Convert offset to cube
                     Vector2Int offsetCoords = new Vector2Int(x, y);
                     Vector3Int cubeCoords = HexUtils.OffsetToCube(offsetCoords, mapData.isFlatTopped, false);
+#if UNITY_EDITOR
                     Debug.Log(offsetCoords.ToString() +  cubeCoords.ToString());
+#endif
 
                     // Create empty GameObject with Tile component
                     GameObject holder = new GameObject($"Hex {x},{y}", typeof(Tile));


### PR DESCRIPTION
## Summary
- remove runtime Debug.Log calls in Board.set_Tile
- guard MapMerge debug output with `UNITY_EDITOR`

## Testing
- `echo "No test script" && true`

------
https://chatgpt.com/codex/tasks/task_e_6853ad59bae8832f94d7497edaba8aac