### PR TITLE
Add rematch option and game restart logic

### DIFF
--- a/Assets/Scripts/CardGame/CardGameStateMachine.cs
+++ b/Assets/Scripts/CardGame/CardGameStateMachine.cs
@@ -27,6 +27,7 @@ public class GameStateMachine : MonoBehaviour
     [SerializeField] private CardBoard cardBoard;
     [SerializeField] private Hand playerHand;
     [SerializeField] private Hand opponentHand;
+    [SerializeField] private GameLayout gameLayout;
 
     [Header("State")]
     [SerializeField] private GameState currentState;
@@ -53,6 +54,11 @@ public class GameStateMachine : MonoBehaviour
 
     private void Start()
     {
+        if (gameLayout == null)
+        {
+            gameLayout = FindObjectOfType<GameLayout>();
+        }
+
         // Subscribe to card placement events
         if (cardBoard != null)
         {
@@ -264,9 +270,34 @@ public class GameStateMachine : MonoBehaviour
 
     public void RestartGame()
     {
+        // Reset board logic (clears data)
         cardBoard.ResetBoard();
-        // TODO: Reset hands and redeal cards
 
+        // Reset visuals and spawn new slate visual
+        // Note: ResetBoard must be called before ResetLayout because SpawnSlateVisual needs the new slate
+        if (gameLayout != null)
+        {
+            gameLayout.ResetLayout();
+        }
+
+        // Reset hands (creates new cards and visuals)
+        if (playerHand != null) playerHand.ResetHand();
+        if (opponentHand != null) opponentHand.ResetHand();
+
+        // Position the new hands
+        if (gameLayout != null)
+        {
+            gameLayout.PositionHands();
+        }
+
+        // Reset state
+        hasStarted = false;
+        hasSwapped = false;
+        isPlayerTurn = false; // Will be set in StartGame
+        IsResolvingDraw = false;
+
+        // Restart flow
+        ChangeState(GameState.GameStart);
     }
     private void FinalizeTurn()
     {

--- a/Assets/Scripts/CardGame/CardGameUI.cs
+++ b/Assets/Scripts/CardGame/CardGameUI.cs
@@ -1,0 +1,75 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+public class CardGameUI : MonoBehaviour
+{
+    [Header("UI References")]
+    [SerializeField] private GameObject gameOverPanel;
+    [SerializeField] private Text resultText;
+    [SerializeField] private Button rematchButton;
+
+    private void Start()
+    {
+        // Subscribe to events
+        if (GameStateMachine.Instance != null)
+        {
+            GameStateMachine.Instance.OnGameEnd += HandleGameEnd;
+            GameStateMachine.Instance.OnStateChanged += HandleStateChanged;
+        }
+
+        if (rematchButton != null)
+        {
+            rematchButton.onClick.AddListener(OnRematchClicked);
+        }
+
+        // Ensure panel is hidden at start
+        if (gameOverPanel != null)
+        {
+            gameOverPanel.SetActive(false);
+        }
+    }
+
+    private void OnDestroy()
+    {
+        if (GameStateMachine.Instance != null)
+        {
+            GameStateMachine.Instance.OnGameEnd -= HandleGameEnd;
+            GameStateMachine.Instance.OnStateChanged -= HandleStateChanged;
+        }
+
+        if (rematchButton != null)
+        {
+            rematchButton.onClick.RemoveListener(OnRematchClicked);
+        }
+    }
+
+    private void HandleGameEnd(bool playerWon)
+    {
+        if (gameOverPanel != null)
+        {
+            gameOverPanel.SetActive(true);
+        }
+
+        if (resultText != null)
+        {
+            resultText.text = playerWon ? "YOU WIN!" : "YOU LOSE!";
+            resultText.color = playerWon ? Color.green : Color.red;
+        }
+    }
+
+    private void HandleStateChanged(GameState newState)
+    {
+        if (newState == GameState.GameStart && gameOverPanel != null)
+        {
+            gameOverPanel.SetActive(false);
+        }
+    }
+
+    private void OnRematchClicked()
+    {
+        if (GameStateMachine.Instance != null)
+        {
+            GameStateMachine.Instance.RestartGame();
+        }
+    }
+}

--- a/Assets/Scripts/CardGame/CardGameUI.cs.meta
+++ b/Assets/Scripts/CardGame/CardGameUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3f09384ca7aa4903bc8634538cfbcbce
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/CardGame/GameLayout.cs
+++ b/Assets/Scripts/CardGame/GameLayout.cs
@@ -190,7 +190,7 @@ public class GameLayout : MonoBehaviour
         }
     }
 
-    private void SpawnSlateVisual()
+    public void SpawnSlateVisual()
     {
         Vector2Int slatePos = cardBoard.FindSlate();
         Slate slate = cardBoard.GetCard(slatePos);
@@ -229,5 +229,21 @@ public class GameLayout : MonoBehaviour
 
             visual.transform.SetParent(transform);
         }
+    }
+
+    public void ClearAllVisuals()
+    {
+        foreach (var visual in cardVisuals.Values)
+        {
+            if (visual != null)
+                Destroy(visual.gameObject);
+        }
+        cardVisuals.Clear();
+    }
+
+    public void ResetLayout()
+    {
+        ClearAllVisuals();
+        SpawnSlateVisual();
     }
 }

--- a/Assets/Scripts/CardGame/Hand.cs
+++ b/Assets/Scripts/CardGame/Hand.cs
@@ -36,6 +36,11 @@ public class Hand : MonoBehaviour
             gameLayout = FindObjectOfType<GameLayout>();
         }
 
+        InitializeHand();
+    }
+
+    public void InitializeHand()
+    {
         foreach (SOCard a in SOPlayerHand)
         {
             Card card = new Card(a, Player);
@@ -45,6 +50,13 @@ public class Hand : MonoBehaviour
             PlayerHand.Add(card);
             handVisualisers.Add(view);
         }
+    }
+
+    public void ResetHand()
+    {
+        PlayerHand.Clear();
+        handVisualisers.Clear();
+        InitializeHand();
     }
 
 

--- a/Assets/Tests/PlayMode/CardGameRestartTests.cs
+++ b/Assets/Tests/PlayMode/CardGameRestartTests.cs
@@ -1,0 +1,106 @@
+using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+public class CardGameRestartTests
+{
+    private GameObject gameObj;
+    private GameStateMachine gameStateMachine;
+    private CardBoard cardBoard;
+    private Hand playerHand;
+    private Hand opponentHand;
+    private GameLayout gameLayout;
+
+    [SetUp]
+    public void Setup()
+    {
+        gameObj = new GameObject("CardGame");
+
+        // Setup components
+        gameStateMachine = gameObj.AddComponent<GameStateMachine>();
+        cardBoard = gameObj.AddComponent<CardBoard>();
+        playerHand = gameObj.AddComponent<Hand>();
+        opponentHand = gameObj.AddComponent<Hand>();
+        gameLayout = gameObj.AddComponent<GameLayout>();
+
+        // Link references using reflection
+        SetPrivateField(gameStateMachine, "cardBoard", cardBoard);
+        SetPrivateField(gameStateMachine, "playerHand", playerHand);
+        SetPrivateField(gameStateMachine, "opponentHand", opponentHand);
+        SetPrivateField(gameStateMachine, "gameLayout", gameLayout);
+
+        SetPrivateField(playerHand, "cardBoard", cardBoard);
+        SetPrivateField(playerHand, "gameLayout", gameLayout);
+        playerHand.Player = true;
+
+        SetPrivateField(opponentHand, "cardBoard", cardBoard);
+        SetPrivateField(opponentHand, "gameLayout", gameLayout);
+        opponentHand.Player = false;
+
+        SetPrivateField(gameLayout, "cardBoard", cardBoard);
+        SetPrivateField(gameLayout, "playerHand", playerHand);
+        SetPrivateField(gameLayout, "enemyHand", opponentHand);
+
+        // Need a SnapProvider for GameLayout
+        var snapProvider = gameObj.AddComponent<GridSnapProvider>();
+        SetPrivateField(gameLayout, "snapProvider", snapProvider);
+
+        // Mock Slate SO for CardBoard
+        var slateSO = ScriptableObject.CreateInstance<SOCard>();
+        SetPrivateField(cardBoard, "slate", slateSO);
+
+        // Initialize Board for tests (creates array, places slate)
+        cardBoard.InitializeForTests(slateSO);
+    }
+
+    [TearDown]
+    public void Teardown()
+    {
+        Object.Destroy(gameObj);
+    }
+
+    [UnityTest]
+    public IEnumerator RestartGame_ResetsStateAndBoard()
+    {
+        // Arrange: Simulate Game Over state
+        gameStateMachine.ChangeState(GameState.GameOver);
+
+        yield return null;
+
+        // Act: Restart Game
+        gameStateMachine.RestartGame();
+
+        yield return null;
+
+        // Assert: State should be GameStart
+        Assert.AreEqual(GameState.GameStart, gameStateMachine.GetCurrentState());
+
+        // Assert: Board should be reset (only 1 item - the slate)
+        int occupiedCount = 0;
+        for(int x=0; x<3; x++)
+        {
+            for(int y=0; y<3; y++)
+            {
+                if (cardBoard.GetCard(new Vector2Int(x,y)) != null)
+                    occupiedCount++;
+            }
+        }
+
+        Assert.AreEqual(1, occupiedCount, "Board should contain exactly 1 slate after restart");
+    }
+
+    private void SetPrivateField(object target, string fieldName, object value)
+    {
+        var field = target.GetType().GetField(fieldName, System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+        if (field != null)
+        {
+            field.SetValue(target, value);
+        }
+        else
+        {
+            Debug.LogError($"Field {fieldName} not found on {target.GetType()}");
+        }
+    }
+}

--- a/Assets/Tests/PlayMode/CardGameRestartTests.cs.meta
+++ b/Assets/Tests/PlayMode/CardGameRestartTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5f02ccb46752424f8aecf87675781a8a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
I thought I stopped this but I got more...... I hope these are actually useful to you.

- Implemented RestartGame in CardGameStateMachine to reset board, hands, and layout.
- Added ResetLayout and ClearAllVisuals to GameLayout for visual cleanup.
- Added ResetHand and InitializeHand to Hand for hand regeneration.
- Created CardGameUI to handle Win/Loss screen and Rematch button.
- Added PlayMode test CardGameRestartTests.