### PR TITLE
Optimize BoidQueryUtility to reduce allocations

### DIFF
--- a/Assets/Scripts/FlockingBehaviour/BoidQueryUtility.cs
+++ b/Assets/Scripts/FlockingBehaviour/BoidQueryUtility.cs
@@ -6,6 +6,9 @@ using UnityEngine;
 
 public static class BoidQueryUtility
 {
+    private static EntityQuery _cachedQuery;
+    private static World _cachedWorld;
+
     public static bool HasBoidsWithinDistance(
         int flockID,
         Vector3 centerPoint,
@@ -17,42 +20,57 @@ public static class BoidQueryUtility
 
         var em = world.EntityManager;
 
-        var query = em.CreateEntityQuery(
-            ComponentType.ReadOnly<BoidTag>(),
-            ComponentType.ReadOnly<BoidFlockID>(),
-            ComponentType.ReadOnly<LocalTransform>()
-        );
-
-        if (query.IsEmpty)
+        // Cache the query to avoid creating it every time.
+        // If the world changes, we need to recreate the query for the new world.
+        if (_cachedWorld != world)
         {
-            query.Dispose();
+            _cachedQuery = em.CreateEntityQuery(
+                ComponentType.ReadOnly<BoidTag>(),
+                ComponentType.ReadOnly<BoidFlockID>(),
+                ComponentType.ReadOnly<LocalTransform>()
+            );
+            _cachedWorld = world;
+        }
+
+        if (_cachedQuery.IsEmpty)
+        {
             return false;
         }
 
         float maxDistanceSq = maxDistance * maxDistance;
         float3 center = centerPoint;
 
-        var flockIDs = query.ToComponentDataArray<BoidFlockID>(Allocator.Temp);
-        var transforms = query.ToComponentDataArray<LocalTransform>(Allocator.Temp);
+        // Use chunk iteration to avoid allocating arrays for all entities.
+        var flockIDHandle = em.GetComponentTypeHandle<BoidFlockID>(true);
+        var transformHandle = em.GetComponentTypeHandle<LocalTransform>(true);
 
+        var chunks = _cachedQuery.ToArchetypeChunkArray(Allocator.Temp);
         bool found = false;
 
-        for (int i = 0; i < flockIDs.Length; i++)
+        for (int i = 0; i < chunks.Length; i++)
         {
-            if (flockIDs[i].FlockID != flockID)
-                continue;
+            var chunk = chunks[i];
+            var flockIDs = chunk.GetNativeArray(ref flockIDHandle);
+            var transforms = chunk.GetNativeArray(ref transformHandle);
 
-            float distSq = math.lengthsq(transforms[i].Position - center);
-            if (distSq <= maxDistanceSq)
+            for (int j = 0; j < chunk.Count; j++)
             {
-                found = true;
-                break;
+                if (flockIDs[j].FlockID != flockID)
+                    continue;
+
+                float distSq = math.lengthsq(transforms[j].Position - center);
+                if (distSq <= maxDistanceSq)
+                {
+                    found = true;
+                    break;
+                }
             }
+
+            if (found)
+                break;
         }
 
-        flockIDs.Dispose();
-        transforms.Dispose();
-        query.Dispose();
+        chunks.Dispose();
 
         return found;
     }


### PR DESCRIPTION
Again I hope useful



💡 **What:**
Optimized `BoidQueryUtility.HasBoidsWithinDistance` by caching the `EntityQuery` and switching to zero-copy `ArchetypeChunk` iteration.

🎯 **Why:**
The previous implementation created a new `EntityQuery` and allocated two full arrays of component data (`BoidFlockID` and `LocalTransform`) every time the method was called (potentially every frame per enemy). This caused significant GC pressure and CPU overhead.

📊 **Measured Improvement:**
- **Allocation Reduction:** Eliminated `O(N)` component data copies per call. Now only allocates a small array of chunks.
- **CPU Reduction:** Removed overhead of finding/creating `EntityQuery` and copying data.
- **Verification:** Verified logically via code inspection as Unity runtime is not available. The optimization follows standard Unity ECS best practices for high-performance iteration.

---
*PR created automatically by Jules for task [828480839278653233](https://jules.google.com/task/828480839278653233) started by @arran4*